### PR TITLE
add traefik_labels config to allow disable reading traefik_labels

### DIFF
--- a/README.docker.md
+++ b/README.docker.md
@@ -271,6 +271,7 @@ environment variables.
 *   `DMU_PREPEND_WWW`    - add _www_ subdomains to all hostnames (default: _False_)
 *   `DMU_DOCKER_SOCKET`  - path to the docker socket (default: _unix://var/run/docker.sock_)
 *   `DMU_NETWORK`        - Docker network to monitor, defaults to none/disabled
+*   `DMU_TRAEFIK_LABELS` - read Traefik labels for hostnames (default: _False_)
 *   `DMU_SERVER`         - _dnsmasq_ server address
 *   `DMU_PORT`           - _dnsmasq_ server SSH port (default: _22_)
 *   `DMU_LOGIN`          - _dnsmasq_ server login name

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Docker:
                         'unix://var/run/docker.sock')
   -n NETWORK, --network NETWORK
                         Docker network to monitor
+  -T, --traefik_labels
+                        read Traefik labels for hostnames
 
 DNS:
   -i IP, --ip IP        default IP for the DNS records
@@ -180,6 +182,8 @@ Docker:
                         path to the docker socket (default: 'unix://var/run/docker.sock')
   -n NETWORK, --network NETWORK
                         Docker network to monitor
+  -T, --traefik_labels
+                        read Traefik labels for hostnames
 
 API:
   -s SERVER, --api_server SERVER
@@ -454,6 +458,7 @@ environment variables.
 *   `DMU_PREPEND_WWW`    - add _www_ subdomains to all hostnames (default: _False_)
 *   `DMU_DOCKER_SOCKET`  - path to the docker socket (default: _unix://var/run/docker.sock_)
 *   `DMU_NETWORK`        - Docker network to monitor, defaults to none/disabled
+*   `DMU_TRAEFIK_LABELS` - read Traefik labels for hostnames (default: _False_)
 *   `DMU_SERVER`         - _dnsmasq_ server address
 *   `DMU_PORT`           - _dnsmasq_ server SSH port (default: _22_)
 *   `DMU_LOGIN`          - _dnsmasq_ server login name
@@ -589,6 +594,9 @@ the manager's default IP.
 Any defined `extra_hosts` will be given the IP from that definition.
 
 ### Use with Traefik
+To configure Docker Dnsmasq Updater to pull Traefik hostnames use the flag
+`--traefik_labels` or the environment variable `DMU_TRAEFIK_LABELS=true`
+
 Docker Dnsmasq Updater will pull Traefik hostnames set on containers via the
 ``traefik.http.routers.<router>.rule=Host(`<hostname>`)`` label, including
 multiple hostnames specified in the

--- a/dnsmasq_updater.conf
+++ b/dnsmasq_updater.conf
@@ -10,6 +10,7 @@ prepend_www=False
 [docker]
 docker_socket=unix://var/run/docker.sock
 network=
+traefik_labels=False
 
 [hosts]
 location=remote

--- a/dnsmasq_updater_agent.conf
+++ b/dnsmasq_updater_agent.conf
@@ -4,6 +4,7 @@ ready_fd=
 [docker]
 docker_socket=unix://var/run/docker.sock
 network=
+traefik_labels=False
 
 [api]
 api_server=

--- a/root/etc/s6-overlay/s6-rc.d/dnsmasq-updater-init/init.sh
+++ b/root/etc/s6-overlay/s6-rc.d/dnsmasq-updater-init/init.sh
@@ -16,6 +16,9 @@ if env | grep -q 'DMU_'; then
 
 	[ ! -z "${DMU_DOCKER_SOCKET}" ] && sed "s!^docker_socket.*!docker_socket=${DMU_DOCKER_SOCKET}!" -i $CONFIG_FILE
 	[ ! -z "${DMU_NETWORK}" ] && sed "s!^network.*!network=${DMU_NETWORK}!" -i $CONFIG_FILE
+	[ ! -z "${DMU_TRAEFIK_LABELS}" ] \
+		&& sed -E "s!^#?traefik_labels.*!traefik_labels=${DMU_TRAEFIK_LABELS}!" -i $CONFIG_FILE \
+		|| sed -E "s!^#?traefik_labels.*!traefik_labels=False!" -i $CONFIG_FILE
 	[ ! -z "${DMU_SERVER}" ] && sed "s!^server.*!server=${DMU_SERVER}!" -i $CONFIG_FILE
 
 	[ ! -z "${DMU_PREPEND_WWW}" ] \


### PR DESCRIPTION
I don't want this to automatically pull the hostnames from Traefik so I've added a flag and config option to disable this function.

I wasn't able to test this though as I couldn't figure out how to build this locally yet.